### PR TITLE
To support DICOM Type 2 for posint values.

### DIFF
--- a/DCC.Core.Types.schema.json
+++ b/DCC.Core.Types.schema.json
@@ -7,7 +7,7 @@
     "dose_posint": {
       "description": "Dose Number / Total doses in Series: positive integer, range: [1,9]",
       "type": "integer",
-      "minimum": 1,
+      "minimum": 0,
       "maximum": 9
     },
     "country_vt": {

--- a/DCC.Core.Types.schema.json
+++ b/DCC.Core.Types.schema.json
@@ -4,8 +4,8 @@
   "title": "EU DCC",
   "description": "EU Digital Covid Certificate Core Data Types",
   "$defs": {
-    "dose_posint": {
-      "description": "Dose Number / Total doses in Series: positive integer, range: [1,9]",
+    "dose_non_neg": {
+      "description": "Dose Number / Total doses in Series: non-negative integer, range: [0,9]",
       "type": "integer",
       "minimum": 0,
       "maximum": 9

--- a/DCC.Types.schema.json
+++ b/DCC.Types.schema.json
@@ -38,11 +38,11 @@
         },
         "dn": {
           "description": "Dose Number",
-          "$ref": "https://id.uvci.eu/DCC.Core.Types.schema.json#/$defs/dose_posint"
+          "$ref": "https://id.uvci.eu/DCC.Core.Types.schema.json#/$defs/dose_non_neg"
         },
         "sd": {
           "description": "Total Series of Doses",
-          "$ref": "https://id.uvci.eu/DCC.Core.Types.schema.json#/$defs/dose_posint"
+          "$ref": "https://id.uvci.eu/DCC.Core.Types.schema.json#/$defs/dose_non_neg"
         },
         "dt": {
           "description": "Date of Vaccination",

--- a/DCC.combined-schema.json
+++ b/DCC.combined-schema.json
@@ -163,11 +163,11 @@
         },
         "dn": {
           "description": "Dose Number",
-          "$ref": "#/$defs/dose_posint"
+          "$ref": "#/$defs/dose_non_neg"
         },
         "sd": {
           "description": "Total Series of Doses",
-          "$ref": "#/$defs/dose_posint"
+          "$ref": "#/$defs/dose_non_neg"
         },
         "dt": {
           "description": "Date of Vaccination",

--- a/DCC.combined-schema.json
+++ b/DCC.combined-schema.json
@@ -62,9 +62,9 @@
   },
   "$defs": {
     "dose_posint": {
-      "description": "Dose Number / Total doses in Series: positive integer, range: [1,9]",
+      "description": "Dose Number / Total doses in Series: positive integer, range: [0,9]",
       "type": "integer",
-      "minimum": 1,
+      "minimum": 0,
       "maximum": 9
     },
     "country_vt": {

--- a/DCC.combined-schema.json
+++ b/DCC.combined-schema.json
@@ -61,8 +61,8 @@
     }
   },
   "$defs": {
-    "dose_posint": {
-      "description": "Dose Number / Total doses in Series: positive integer, range: [0,9]",
+    "dose_non_neg": {
+      "description": "Dose Number / Total doses in Series: non-negative integer, range: [0,9]",
       "type": "integer",
       "minimum": 0,
       "maximum": 9


### PR DESCRIPTION
https://github.com/ehn-digital-green-development/ehn-dgc-schema/pull/new/unknown-value-support

Describes support for DICOM type 2 value solutions. Other fields only specify a maxlen (string) or minimum data in ISO 8601