### PR TITLE
Improved transliteration examples

### DIFF
--- a/examples/recovery/transliterated.json
+++ b/examples/recovery/transliterated.json
@@ -2,9 +2,9 @@
   "ver": "1.3.0",
   "nam": {
     "fn": "ابو بكر محمد بن زكريا الرازي",
-    "fnt": "ABU<BAKR<MOHAMMED<IBN<ZAKARIA<AL<RAZI",
+    "fnt": "ABW<BKR<MXHMD<BN<ZKRYA<ALRAZY",
     "gn": "ناصر",
-    "gnt": "NASR"
+    "gnt": "NAXSSR"
   },
   "dob": "1964",
   "r": [

--- a/examples/test/transliterated.json
+++ b/examples/test/transliterated.json
@@ -2,9 +2,9 @@
   "ver": "1.3.0",
   "nam": {
     "fn": "ابو بكر محمد بن زكريا الرازي",
-    "fnt": "ABU<BAKR<MOHAMMED<IBN<ZAKARIA<AL<RAZI",
+    "fnt": "ABW<BKR<MXHMD<BN<ZKRYA<ALRAZY",
     "gn": "ناصر",
-    "gnt": "NASR"
+    "gnt": "NAXSSR"
   },
   "dob": "1964",
   "t": [

--- a/examples/vaccination/transliterated.json
+++ b/examples/vaccination/transliterated.json
@@ -2,9 +2,9 @@
   "ver": "1.3.0",
   "nam": {
     "fn": "ابو بكر محمد بن زكريا الرازي",
-    "fnt": "ABU<BAKR<MOHAMMED<IBN<ZAKARIA<AL<RAZI",
+    "fnt": "ABW<BKR<MXHMD<BN<ZKRYA<ALRAZY",
     "gn": "ناصر",
-    "gnt": "NASR"
+    "gnt": "NAXSSR"
   },
   "dob": "1964",
   "v": [


### PR DESCRIPTION
Examples improved by using the MRTD transliteration rule, from document 9303 for Standard Arabic.

See: https://www.icao.int/publications/Documents/9303_p3_cons_en.pdf.

The tables use start are on p42 of the PDF. On page 77 of the PDF can be found the Standard Arabic example from the surname field. Both my manual transliteration and my script produced the exact same output as in the provided example.