### PR TITLE
Script update to new JRC API

### DIFF
--- a/valuesets/source-update/update-rat.sh
+++ b/valuesets/source-update/update-rat.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
-curl --silent --show-error https://covid-19-diagnostics.jrc.ec.europa.eu/devices/hsc-common-recognition-rat |
-jq '.extracted_on as $version | .deviceList | reduce .[] as $i
-({};
-.[$i.id_device] =
-{ "display": ($i.manufacturer.name + ", " + $i.commercial_name),
-    "lang":"en",
-    "active": true,
-    "system": "https://covid-19-diagnostics.jrc.ec.europa.eu/devices",
-    "version": $i.last_updated
-}) | {"valueSetId": "covid-19-lab-test-manufacturer-and-name", "valueSetDate":$version[0:10], "valueSetValues": .}'
+curl --silent --show-error https://covid-19-diagnostics.jrc.ec.europa.eu/devices/hsc-common-recognition-rat | jq \
+'{
+  "valueSetId": "covid-19-lab-test-manufacturer-and-name",
+  "valueSetDate": .extracted_on[0:10],
+  "valueSetValues":
+(reduce .deviceList[] as $i ({}; .[$i.id_device] =
+($i.hsc_list_history | sort_by(.list_date)[-1]) as $latest |
+{
+  "display": ($i.manufacturer.name + ", " + $i.commercial_name),
+  "system": "https://covid-19-diagnostics.jrc.ec.europa.eu/devices",
+  "version":  (if $latest.in_common_list then $i.last_updated else $latest.list_date end),
+  "lang": "en",
+  "active": $latest.in_common_list }))
+}'


### PR DESCRIPTION
RAT-list script is now using new JRC API. Value set now includes also entries removed from the RAT common list with removal date and time information stored in the version attribute. This is a slightly updated script created by Daniel Karlsson.
