### PR TITLE
Avoid Additional Fields

### DIFF
--- a/DCC.combined-schema.json
+++ b/DCC.combined-schema.json
@@ -5,6 +5,7 @@
   "description": "EU Digital Covid Certificate",
   "$comment": "Schema version 1.3.0",
   "type": "object",
+  "additionalProperties": false,
   "oneOf": [
     {
       "required": [


### PR DESCRIPTION
Please add this flag to the schema to avoid the issuing of extra fields. Additional fields other than in the regulation are not allowed. 